### PR TITLE
scaler.yml: Never recognized due to "kind: hpa"

### DIFF
--- a/artifacts/kubes/scaling/scaler.yml
+++ b/artifacts/kubes/scaling/scaler.yml
@@ -9,7 +9,7 @@ spec:
     apiVersion: autoscaling/v1
   steps:
   #run at 5:30 UTC
-  - runat: '0 40 14 * * *'
+  - runat: '0 30 5 * * *'
     mode: range
     minReplicas: 1
     maxReplicas: 5

--- a/artifacts/kubes/scaling/scaler.yml
+++ b/artifacts/kubes/scaling/scaler.yml
@@ -4,7 +4,7 @@ metadata:
   name: my-scheduled-scaler-1
 spec:
   target:
-    kind: hpa
+    kind: HorizontalPodAutoscaler
     name: my-hpa-1
     apiVersion: autoscaling/v1
   steps:


### PR DESCRIPTION
I struggled with getting my scheduled scaler to work.
I based it on the example at `artifacts/kubes/scaling/scaler.yml`, which has "hpa" as the value for spec.target.kind.

[scaling-controller.go#L77](https://github.com/k8s-restdev/scheduled-scaler/blob/f8b7d2b1fee8a4b52ed17367091ea22b85b9d0a7/scaling-controller.go) seems to be only interested for kind values of "HorizontalPodAutoscaler" or "InstanceGroup".
So changing kind to "HorizontalPodAutoscaler" made it work for me, as expected.

I'm sending a pull request to keep others from running into the same problem.

---

Details on my environment:
Google Kubernetes Engine
Kubernetes Version: 1.9.3-gke.0
scheduled-scaler Version: [e716936](https://github.com/k8s-restdev/scheduled-scaler/commit/e716936530aebed96bd3ec4d239476a2c4254233)