### PR TITLE
Updated RBAC and CDR API versions

### DIFF
--- a/artifacts/kubes/scaling/chart/templates/crd.yaml
+++ b/artifacts/kubes/scaling/chart/templates/crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>

--- a/artifacts/kubes/scaling/chart/templates/crd.yaml
+++ b/artifacts/kubes/scaling/chart/templates/crd.yaml
@@ -6,8 +6,49 @@ metadata:
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: scaling.k8s.restdev.com
-  # version name to use for REST API: /apis/<group>/<version>
-  version: v1alpha1
+  versions:
+    # version name to use for REST API: /apis/<group>/<version>
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                timeZone:
+                  type: string
+                target:
+                  type: object
+                  properties:
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    apiVersion:
+                      type: string
+                  required: ["kind", "name", "apiVersion"]
+                steps:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      runat:
+                        type: string
+                        pattern: "^(((\\d+|\\d+(-|\\/)\\d+)(,(\\d+|\\d+(-|\\/)\\d+))*|\\*) ){5}((\\d+|\\d+(-|\\/)\\d+)(,(\\d+|\\d+(-|\\/)\\d+))*|\\*)$"
+                      mode:
+                        type: string
+                        pattern: "^(fixed|range)$"
+                      replicas:
+                        type: integer
+                      minReplicas:
+                        type: integer
+                      maxReplicas:
+                        type: integer
+                    required: ["runat", "mode"]
+              required: ["target", "steps"]
   # either Namespaced or Cluster
   scope: Namespaced
   names:

--- a/artifacts/kubes/scaling/chart/templates/crd.yaml
+++ b/artifacts/kubes/scaling/chart/templates/crd.yaml
@@ -13,39 +13,53 @@ spec:
       storage: true
       schema:
         openAPIV3Schema:
+          description: "ScheduledScaler is the Schema for the scheduled-scaler API"
           type: object
           properties:
             spec:
+              description: "ScheduledScalerSpec is the specification of a ScheduledScaler"
               type: object
               properties:
                 timeZone:
+                  description: "Timezone to use for the cronjob"
                   type: string
                 target:
+                  description: "Target to scale"
                   type: object
                   properties:
                     kind:
+                      description: "Kind of the target (InstanceGroup/HorizontalPodAutoscaler)"
                       type: string
                     name:
+                      description: "Name of the target resource"
                       type: string
                     apiVersion:
+                      description: "API version of the target resource"
                       type: string
                   required: ["kind", "name", "apiVersion"]
                 steps:
+                  description: "List of steps to scale the target resource at a specific time."
                   type: array
                   items:
+                    description: "Step to scale the target resource at a specific time."
                     type: object
                     properties:
                       runat:
+                        description: "Cronjob time string (gocron) to run the scaling. Uses Cron Expression Format, https://pkg.go.dev/github.com/robfig/cron#hdr-CRON_Expression_Format"
                         type: string
                         pattern: "^(((\\d+|\\d+(-|\\/)\\d+)(,(\\d+|\\d+(-|\\/)\\d+))*|\\*) ){5}((\\d+|\\d+(-|\\/)\\d+)(,(\\d+|\\d+(-|\\/)\\d+))*|\\*)$"
                       mode:
+                        description: "Type of scaling to run. 'fixed': set replicas to a fixed value, 'range': set replicas to a range"
                         type: string
                         pattern: "^(fixed|range)$"
                       replicas:
+                        description: "Number of replicas to set when mode is 'fixed'"
                         type: integer
                       minReplicas:
+                        description: "Minimum number of replicas to set when mode is 'range'"
                         type: integer
                       maxReplicas:
+                        description: "Maximum number of replicas to set when mode is 'range'"
                         type: integer
                     required: ["runat", "mode"]
               required: ["target", "steps"]

--- a/artifacts/kubes/scaling/chart/templates/rbac.yaml
+++ b/artifacts/kubes/scaling/chart/templates/rbac.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create -}}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "scheduled-scaler.fullname" . }}
 rules:
@@ -26,7 +26,7 @@ metadata:
   name: {{ template "scheduled-scaler.fullname" . }}
   namespace: {{ .Release.Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "scheduled-scaler.fullname" . }}

--- a/artifacts/kubes/scaling/crd.yml
+++ b/artifacts/kubes/scaling/crd.yml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>

--- a/artifacts/kubes/scaling/crd.yml
+++ b/artifacts/kubes/scaling/crd.yml
@@ -6,7 +6,6 @@ metadata:
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: scaling.k8s.restdev.com
-  # version name to use for REST API: /apis/<group>/<version>
   versions:
     # version name to use for REST API: /apis/<group>/<version>
     - name: v1alpha1
@@ -14,39 +13,53 @@ spec:
       storage: true
       schema:
         openAPIV3Schema:
+          description: "ScheduledScaler is the Schema for the scheduled-scaler API"
           type: object
           properties:
             spec:
+              description: "ScheduledScalerSpec is the specification of a ScheduledScaler"
               type: object
               properties:
                 timeZone:
+                  description: "Timezone to use for the cronjob"
                   type: string
                 target:
+                  description: "Target to scale"
                   type: object
                   properties:
                     kind:
+                      description: "Kind of the target (InstanceGroup/HorizontalPodAutoscaler)"
                       type: string
                     name:
+                      description: "Name of the target resource"
                       type: string
                     apiVersion:
+                      description: "API version of the target resource"
                       type: string
                   required: ["kind", "name", "apiVersion"]
                 steps:
+                  description: "List of steps to scale the target resource at a specific time."
                   type: array
                   items:
+                    description: "Step to scale the target resource at a specific time."
                     type: object
                     properties:
                       runat:
+                        description: "Cronjob time string (gocron) to run the scaling. Uses Cron Expression Format, https://pkg.go.dev/github.com/robfig/cron#hdr-CRON_Expression_Format"
                         type: string
                         pattern: "^(((\\d+|\\d+(-|\\/)\\d+)(,(\\d+|\\d+(-|\\/)\\d+))*|\\*) ){5}((\\d+|\\d+(-|\\/)\\d+)(,(\\d+|\\d+(-|\\/)\\d+))*|\\*)$"
                       mode:
+                        description: "Type of scaling to run. 'fixed': set replicas to a fixed value, 'range': set replicas to a range"
                         type: string
                         pattern: "^(fixed|range)$"
                       replicas:
+                        description: "Number of replicas to set when mode is 'fixed'"
                         type: integer
                       minReplicas:
+                        description: "Minimum number of replicas to set when mode is 'range'"
                         type: integer
                       maxReplicas:
+                        description: "Maximum number of replicas to set when mode is 'range'"
                         type: integer
                     required: ["runat", "mode"]
               required: ["target", "steps"]

--- a/artifacts/kubes/scaling/crd.yml
+++ b/artifacts/kubes/scaling/crd.yml
@@ -7,7 +7,49 @@ spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: scaling.k8s.restdev.com
   # version name to use for REST API: /apis/<group>/<version>
-  version: v1alpha1
+  versions:
+    # version name to use for REST API: /apis/<group>/<version>
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                timeZone:
+                  type: string
+                target:
+                  type: object
+                  properties:
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    apiVersion:
+                      type: string
+                  required: ["kind", "name", "apiVersion"]
+                steps:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      runat:
+                        type: string
+                        pattern: "^(((\\d+|\\d+(-|\\/)\\d+)(,(\\d+|\\d+(-|\\/)\\d+))*|\\*) ){5}((\\d+|\\d+(-|\\/)\\d+)(,(\\d+|\\d+(-|\\/)\\d+))*|\\*)$"
+                      mode:
+                        type: string
+                        pattern: "^(fixed|range)$"
+                      replicas:
+                        type: integer
+                      minReplicas:
+                        type: integer
+                      maxReplicas:
+                        type: integer
+                    required: ["runat", "mode"]
+              required: ["target", "steps"]
   # either Namespaced or Cluster
   scope: Namespaced
   names:


### PR DESCRIPTION
- Updated RBAC API version.
  The `rbac.authorization.k8s.io/v1beta1` API version of ClusterRole and ClusterRoleBinding is no longer served as of [Kubernetes v1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122).
- Updated CRD API version. Added required `openAPIV3Schema`.
  The `apiextensions.k8s.io/v1beta1` API version of CustomResourceDefinition is no longer served as of [Kubernetes v1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122).
- Added descriptions to CRD

Tested on Kubernetes v1.28.3

Errors without these fixes:
> The Kubernetes API could not find version "v1beta1" of rbac.authorization.k8s.io/ClusterRole for requested resource scheduled-scaler/scheduled-scaler. Version "v1" of rbac.authorization.k8s.io/ClusterRole is installed on the destination cluster.

> The Kubernetes API could not find version "v1beta1" of rbac.authorization.k8s.io/ClusterRoleBinding for requested resource scheduled-scaler/scheduled-scaler. Version "v1" of rbac.authorization.k8s.io/ClusterRoleBinding is installed on the destination cluster.

> The Kubernetes API could not find version "v1beta1" of apiextensions.k8s.io/CustomResourceDefinition for requested resource scheduled-scaler/scheduledscalers.scaling.k8s.restdev.com. Version "v1" of apiextensions.k8s.io/CustomResourceDefinition is installed on the destination cluster.
