### PR TITLE
Use image 1.0.0 in helm chart, bump version of Helm chart to 1.0.1

### DIFF
--- a/artifacts/kubes/scaling/chart/Chart.yaml
+++ b/artifacts/kubes/scaling/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Scheduled Scaler Helm Chart
 name: scheduled-scaler
-version: 0.0.4
+version: 1.0.1

--- a/artifacts/kubes/scaling/chart/values.yaml
+++ b/artifacts/kubes/scaling/chart/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: k8srestdev/scaling
-  tag: 0.0.4
+  tag: 1.0.0
   pullPolicy: Always
 sslCerts:
   hostPath: "/etc/ssl/certs"


### PR DESCRIPTION
- Updated container image to 1.0.0 in the Helm chart
- Bump version of Helm chart to 1.0.1